### PR TITLE
feat: add arg required_key_hashes to verify(...)

### DIFF
--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -11,13 +11,15 @@ from tests.mytest import MyTest
 
 class VerifierTestCase(MyTest):
 
+    CRX_FILE = os.path.join(EXAMPLE_EXTENSION_DIR, EXAMPLE_EXTENSION_NAME + '.crx')
+    PUBLIC_KEY_FILE = os.path.join(EXAMPLE_EXTENSION_DIR, EXAMPLE_EXTENSION_NAME + '-public-key.pem')
+    PUBLIC_KEY_HASH = '99ec6d34093cd254def8c05e5fd5b25ebfef20f97d976eceba28b970da7d81b9'
+
     def test_01_verify_ok_full(self):
-        crx_file = os.path.join(EXAMPLE_EXTENSION_DIR, EXAMPLE_EXTENSION_NAME + '.crx')
-        public_key_file = os.path.join(EXAMPLE_EXTENSION_DIR, EXAMPLE_EXTENSION_NAME + '-public-key.pem')
-        verifier_result, header_info = verifier.verify(crx_file)
+        verifier_result, header_info = verifier.verify(self.CRX_FILE)
         # print(verifier_result, header_info)
         self.assertEqual(verifier_result, verifier.VerifierResult.OK_FULL)
-        public_key = read_public_key_str(public_key_file)
+        public_key = read_public_key_str(self.PUBLIC_KEY_FILE)
         self.assertEqual(header_info, verifier.CrxHeaderInfo(EXAMPLE_EXTENSION_CRX_ID, public_key))
 
     def test_02_verify_error_file_not_readable(self):
@@ -44,6 +46,19 @@ class VerifierTestCase(MyTest):
         verifier_result, header_info = verifier.verify(header_error_file)
         # print(verifier_result, header_info)
         self.assertEqual(verifier_result, verifier.VerifierResult.ERROR_SIGNATURE_VERIFICATION_FAILED)
+        self.assertEqual(header_info, None)
+
+    def test_05_verify_ok_full_with_required_key_hashes(self):
+        verifier_result, header_info = verifier.verify(self.CRX_FILE, [self.PUBLIC_KEY_HASH])
+        # print(verifier_result, header_info)
+        self.assertEqual(verifier_result, verifier.VerifierResult.OK_FULL)
+        public_key = read_public_key_str(self.PUBLIC_KEY_FILE)
+        self.assertEqual(header_info, verifier.CrxHeaderInfo(EXAMPLE_EXTENSION_CRX_ID, public_key))
+
+    def test_06_verify_fail_for_required_key_hashes(self):
+        verifier_result, header_info = verifier.verify(self.CRX_FILE, ['0' * 64])
+        # print(verifier_result, header_info)
+        self.assertEqual(verifier_result, verifier.VerifierResult.ERROR_REQUIRED_PROOF_MISSING)
         self.assertEqual(header_info, None)
 
 


### PR DESCRIPTION
The Chromium implementation for verifying CRX files makes it possible to supply a list of required key hashes that a CRX file must be signed with. This PR adds the same (optional) functionality to python-crx3.

Thank you for the useful library!